### PR TITLE
Job specification creation removal

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -27,7 +27,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-14/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -18,7 +18,19 @@ class Job {
 
     Job(int theId, int[] taskSpecifications) {
         id = theId;
+        taskQ = new LinkedQueue();
         addTasksFromSpecifications(taskSpecifications);
+    }
+
+    Job(int theId, Task[] theTasks){
+        id = theId;
+        taskQ = new LinkedQueue();
+        for (Task theTask: theTasks){
+            if (theTask != null){
+                taskQ.put(theTask);
+            }
+        }
+
     }
 
     // other methods

--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -17,15 +17,25 @@ class Job {
     }
 
     // other methods
+
+    /**
+     * @deprecated
+     * @param theMachine
+     * @param theTime
+     */
     public void addTask(int theMachine, int theTime) {
-        getTaskQ().put(new Task(theMachine, theTime));
+        taskQ.put(new Task(theMachine, theTime));
+    }
+
+    public void addTask(Task theTask) {
+        taskQ.put(theTask);
     }
 
     /**
      * remove next task of job and return its time also update length
      */
     public int removeNextTask() {
-        int theTime = ((Task) getTaskQ().remove()).getTime();
+        int theTime = ((Task) taskQ.remove()).getTime();
         length = getLength() + theTime;
         return theTime;
     }

--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -1,5 +1,7 @@
 package applications;
 
+import java.util.ArrayList;
+
 import dataStructures.LinkedQueue;
 
 class Job {
@@ -83,6 +85,21 @@ class Job {
 	        int theTaskTime = taskSpecifications[j + 1];
 	        addTask(theMachine, theTaskTime); // add to
 	    } // task queue
-	}
+    }
+
+    public JobSpecification getSpecificationFromJob() {
+        JobSpecification output = new JobSpecification();
+        int numTasks = taskQ.size();
+        int[] outputArray = new int[2*numTasks+1];
+        int i = 1;
+        for(Object theTask: taskQ.toArrayList()){
+            outputArray[2 * (i - 1) + 1] = ((Task) theTask).getMachine();
+            outputArray[2 * (i - 1) + 2] = ((Task) theTask).getTime();
+            i++;
+        }
+        output.setSpecificationsForTasks(outputArray);
+        output.setNumTasks(numTasks);
+        return output;        
+    }
 
 }

--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -80,7 +80,8 @@ class Job {
     }
 
 	void addTasksFromSpecifications(int[] taskSpecifications) {
-	    for (int j = 1; j <= taskSpecifications.length - 1; j += 2) {
+
+	    for (int j = 1; j < taskSpecifications.length - 1; j += 2) {
 	        int theMachine = taskSpecifications[j];
 	        int theTaskTime = taskSpecifications[j + 1];
 	        addTask(theMachine, theTaskTime); // add to

--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -16,6 +16,11 @@ class Job {
         // length and arrivalTime have default value 0
     }
 
+    Job(int theId, int[] taskSpecifications) {
+        id = theId;
+        addTasksFromSpecifications(taskSpecifications);
+    }
+
     // other methods
 
     /**
@@ -59,5 +64,13 @@ class Job {
     public int getId() {
         return id;
     }
+
+	void addTasksFromSpecifications(int[] taskSpecifications) {
+	    for (int j = 1; j <= taskSpecifications.length - 1; j += 2) {
+	        int theMachine = taskSpecifications[j];
+	        int theTaskTime = taskSpecifications[j + 1];
+	        addTask(theMachine, theTaskTime); // add to
+	    } // task queue
+	}
 
 }

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -111,7 +111,8 @@ public class MachineShopSimulator {
     }
 
     /** load first jobs onto each machine
-     * @param specification*/
+     * @param specification
+     * */
     void startShop(SimulationSpecification specification) {
         // Move this to startShop when ready
         numMachines = specification.getNumMachines();
@@ -129,7 +130,8 @@ public class MachineShopSimulator {
     }
 
     /** process all jobs to completion
-     * @param simulationResults*/
+     * @param simulationResults
+     * */
     void simulate(SimulationResults simulationResults) {
         while (numJobs > 0) {// at least one job left
             int nextToFinish = eList.nextEventMachine();
@@ -144,7 +146,8 @@ public class MachineShopSimulator {
     }
 
     /** output wait times at machines
-     * @param simulationResults*/
+     * @param simulationResults
+     * */
     void outputStatistics(SimulationResults simulationResults) {
         simulationResults.setFinishTime(timeNow);
         simulationResults.setNumMachines(numMachines);

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -86,17 +86,20 @@ public class MachineShopSimulator {
         // input the jobs
         Job theJob;
         for (int i = 1; i <= specification.getNumJobs(); i++) {
-            int tasks = specification.getJobSpecifications(i).getNumTasks();
             int firstMachine = 0; // machine for first task
 
             // create the job
             theJob = new Job(i);
             int[] taskSpecifications = specification.getJobSpecifications(i).getSpecificationsForTasks();
-            for (int j = 1; j <= tasks; j++) {
-                int theMachine = taskSpecifications[2*(j-1)+1];
-                int theTaskTime = taskSpecifications[2*(j-1)+2];
-                if (j == 1)
-                    firstMachine = theMachine; // job's first machine
+
+            // Note that taskSpecifications is an array of integers with values alternating
+            // between machine numbers and task times.  This is on the chopping block for
+            // priority refactoring, but preliminary work is being done first.
+
+            firstMachine = taskSpecifications[1];
+            for (int j = 1; j <= taskSpecifications.length - 1; j += 2) {
+                int theMachine = taskSpecifications[j];
+                int theTaskTime = taskSpecifications[j + 1];
                 theJob.addTask(theMachine, theTaskTime); // add to
             } // task queue
             machine[firstMachine].getJobQ().put(theJob);

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -91,9 +91,10 @@ public class MachineShopSimulator {
 
             // create the job
             theJob = new Job(i);
+            int[] taskSpecifications = specification.getJobSpecifications(i).getSpecificationsForTasks();
             for (int j = 1; j <= tasks; j++) {
-                int theMachine = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+1];
-                int theTaskTime = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+2];
+                int theMachine = taskSpecifications[2*(j-1)+1];
+                int theTaskTime = taskSpecifications[2*(j-1)+2];
                 if (j == 1)
                     firstMachine = theMachine; // job's first machine
                 theJob.addTask(theMachine, theTaskTime); // add to

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -97,11 +97,7 @@ public class MachineShopSimulator {
             // priority refactoring, but preliminary work is being done first.
 
             firstMachine = taskSpecifications[1];
-            for (int j = 1; j <= taskSpecifications.length - 1; j += 2) {
-                int theMachine = taskSpecifications[j];
-                int theTaskTime = taskSpecifications[j + 1];
-                theJob.addTask(theMachine, theTaskTime); // add to
-            } // task queue
+            theJob.addTasksFromSpecifications(taskSpecifications);
             machine[firstMachine].getJobQ().put(theJob);
         }
     }

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -37,9 +37,11 @@ public class SimulationSpecification {
      * @deprecated
      * @param jobNumber
      * @param specificationsForTasks
+     * Automatically applies tasks to the appropriate job.
      */
     public void setSpecificationsForTasks(int jobNumber, int[] specificationsForTasks) {
         jobSpecifications[jobNumber].setSpecificationsForTasks(specificationsForTasks);
+        jobs[jobNumber].addTasksFromSpecifications(specificationsForTasks);
     }
 
     /**

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -7,6 +7,7 @@ public class SimulationSpecification {
     private int numJobs;
     private int[] changeOverTimes;
     private JobSpecification[] jobSpecifications;
+    private Job[] jobs;
 
     public void setNumMachines(int numMachines) {
         this.numMachines = numMachines;
@@ -44,9 +45,13 @@ public class SimulationSpecification {
     /**
      * @deprecated
      * @param jobSpecifications
+     * Automatically sets up Jobs, given specifications.
      */
     public void setJobSpecification(JobSpecification[] jobSpecifications) {
         this.jobSpecifications = jobSpecifications;
+        for(int i = 1; i < jobSpecifications.length; i++) {
+            jobs[i] = new Job(i, jobSpecifications[i].getSpecificationsForTasks());
+        }
     }
 
     /**
@@ -55,7 +60,12 @@ public class SimulationSpecification {
      * @return
      */
     public JobSpecification getJobSpecifications(int jobNumber) {
-        return jobSpecifications[jobNumber];
+        //return jobSpecifications[jobNumber];
+        return jobs[jobNumber].getSpecificationFromJob();
+    }
+
+    public void setJobs(Job[] theJobs) {
+        this.jobs = theJobs;
     }
     
     @Override

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -51,8 +51,13 @@ public class SimulationSpecification {
      */
     public void setJobSpecification(JobSpecification[] jobSpecifications) {
         this.jobSpecifications = jobSpecifications;
+        jobs = new Job[jobSpecifications.length];
         for(int i = 1; i < jobSpecifications.length; i++) {
-            jobs[i] = new Job(i, jobSpecifications[i].getSpecificationsForTasks());
+            if (jobSpecifications[i].getSpecificationsForTasks() != null) {
+                jobs[i] = new Job(i, jobSpecifications[i].getSpecificationsForTasks());
+            } else {
+                jobs[i] = new Job(i);
+            }
         }
     }
 

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -32,18 +32,32 @@ public class SimulationSpecification {
         return changeOverTimes[machineNumber];
     }
 
+    /**
+     * @deprecated
+     * @param jobNumber
+     * @param specificationsForTasks
+     */
     public void setSpecificationsForTasks(int jobNumber, int[] specificationsForTasks) {
         jobSpecifications[jobNumber].setSpecificationsForTasks(specificationsForTasks);
     }
 
+    /**
+     * @deprecated
+     * @param jobSpecifications
+     */
     public void setJobSpecification(JobSpecification[] jobSpecifications) {
         this.jobSpecifications = jobSpecifications;
     }
 
+    /**
+     * @deprecated
+     * @param jobNumber
+     * @return
+     */
     public JobSpecification getJobSpecifications(int jobNumber) {
         return jobSpecifications[jobNumber];
     }
-
+    
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();

--- a/src/applications/SpecificationReader.java
+++ b/src/applications/SpecificationReader.java
@@ -15,7 +15,7 @@ public class SpecificationReader {
 
     private void readChangeOverTimes() {
         // input the change-over times
-        int[] changeOverTimes = new int[specification.getNumMachines()+1];
+        int[] changeOverTimes = new int[specification.getNumMachines() + 1];
 
         System.out.println("Enter change-over times for machines");
         for (int j = 1; j <= specification.getNumMachines(); j++) {
@@ -28,10 +28,13 @@ public class SpecificationReader {
         specification.setChangeOverTimes(changeOverTimes);
     }
 
+    /**
+     * @deprecated
+     */
     private void readJobSpecifications() {
         // input the jobs
-        JobSpecification[] jobSpecifications = new JobSpecification[specification.getNumJobs()+1];
-        for (int i=1; i <= specification.getNumJobs(); i++) {
+        JobSpecification[] jobSpecifications = new JobSpecification[specification.getNumJobs() + 1];
+        for (int i = 1; i <= specification.getNumJobs(); i++) {
             jobSpecifications[i] = new JobSpecification();
         }
         specification.setJobSpecification(jobSpecifications);
@@ -44,19 +47,41 @@ public class SpecificationReader {
 
             int[] specificationsForTasks = new int[2 * tasks + 1];
 
-            System.out.println("Enter the tasks (machine, time)"
-                    + " in process order");
+            System.out.println("Enter the tasks (machine, time)" + " in process order");
             for (int j = 1; j <= tasks; j++) { // get tasks for job i
                 int theMachine = keyboard.readInteger();
                 int theTaskTime = keyboard.readInteger();
-                if (theMachine < 1 || theMachine > specification.getNumMachines()
-                        || theTaskTime < 1)
+                if (theMachine < 1 || theMachine > specification.getNumMachines() || theTaskTime < 1)
                     throw new MyInputException(MachineShopSimulator.BAD_MACHINE_NUMBER_OR_TASK_TIME);
-                specificationsForTasks[2*(j-1)+1] = theMachine;
-                specificationsForTasks[2*(j-1)+2] = theTaskTime;
+                specificationsForTasks[2 * (j - 1) + 1] = theMachine;
+                specificationsForTasks[2 * (j - 1) + 2] = theTaskTime;
             }
             specification.setSpecificationsForTasks(i, specificationsForTasks);
         }
+    }
+
+    private void readJob() {
+        Job[] theJobs = new Job[specification.getNumJobs() + 1];
+        for (int i = 1; i <= specification.getNumJobs(); i++) {
+            System.out.println("Enter number of tasks for job " + i);
+
+            int numTasks = keyboard.readInteger(); // number of tasks
+            if (numTasks < 1) {
+                throw new MyInputException(MachineShopSimulator.EACH_JOB_MUST_HAVE_AT_LEAST_1_TASK);
+            }
+
+            System.out.println("Enter the tasks (machine, time)" + " in process order");
+
+            Task[] theTasks = new Task[specification.getNumJobs() + 1];
+            for (int j = 1; j <= numTasks; j++) { // Yes, I'm working with a 1 indexed array of my own.  I need to be compatible with and similar to
+                                                  // all the other garbage.  I want to fix it, but that's its own problem.
+                int theMachine = keyboard.readInteger();
+                int theTaskTime = keyboard.readInteger();
+                theTasks[j] = new Task(theMachine, theTaskTime);
+            }
+            theJobs[i] = new Job(i, theTasks);
+        }
+
     }
 
     private void readNumberMachinesAndJobs() {

--- a/src/applications/SpecificationReader.java
+++ b/src/applications/SpecificationReader.java
@@ -72,7 +72,7 @@ public class SpecificationReader {
 
             System.out.println("Enter the tasks (machine, time)" + " in process order");
 
-            Task[] theTasks = new Task[specification.getNumJobs() + 1];
+            Task[] theTasks = new Task[numTasks + 1];
             for (int j = 1; j <= numTasks; j++) { // Yes, I'm working with a 1 indexed array of my own.  I need to be compatible with and similar to
                                                   // all the other garbage.  I want to fix it, but that's its own problem.
                 int theMachine = keyboard.readInteger();

--- a/src/applications/SpecificationReader.java
+++ b/src/applications/SpecificationReader.java
@@ -60,7 +60,7 @@ public class SpecificationReader {
         }
     }
 
-    private void readJob() {
+    private void readJobs() {
         Job[] theJobs = new Job[specification.getNumJobs() + 1];
         for (int i = 1; i <= specification.getNumJobs(); i++) {
             System.out.println("Enter number of tasks for job " + i);
@@ -77,11 +77,14 @@ public class SpecificationReader {
                                                   // all the other garbage.  I want to fix it, but that's its own problem.
                 int theMachine = keyboard.readInteger();
                 int theTaskTime = keyboard.readInteger();
+                if (theMachine < 1 || theMachine > specification.getNumMachines() || theTaskTime < 1){
+                    throw new MyInputException(MachineShopSimulator.BAD_MACHINE_NUMBER_OR_TASK_TIME);
+                }
                 theTasks[j] = new Task(theMachine, theTaskTime);
             }
             theJobs[i] = new Job(i, theTasks);
         }
-
+        specification.setJobs(theJobs);
     }
 
     private void readNumberMachinesAndJobs() {
@@ -100,7 +103,7 @@ public class SpecificationReader {
     public SimulationSpecification readSpecification() {
         readNumberMachinesAndJobs();
         readChangeOverTimes();
-        readJobSpecifications();
+        readJobs();
         return specification;
     }
 }

--- a/src/dataStructures/LinkedQueue.java
+++ b/src/dataStructures/LinkedQueue.java
@@ -109,7 +109,7 @@ public class LinkedQueue implements Queue {
         ArrayList<Object> output = new ArrayList<Object>();
         ChainNode node = front;
         while (node != null) {
-            output.add(node);
+            output.add(node.element);
             node = node.next;
         }
         return output;

--- a/src/dataStructures/LinkedQueue.java
+++ b/src/dataStructures/LinkedQueue.java
@@ -2,6 +2,8 @@
 
 package dataStructures;
 
+import java.util.ArrayList;
+
 public class LinkedQueue implements Queue {
     // data members
     protected ChainNode front;
@@ -101,6 +103,16 @@ public class LinkedQueue implements Queue {
             System.out.println("Front element is " + q.getFrontElement());
             System.out.println("Removed the element " + q.remove());
         }
+    }
+
+    public ArrayList<Object> toArrayList() {
+        ArrayList<Object> output = new ArrayList<Object>();
+        ChainNode node = front;
+        while (node != null) {
+            output.add(node);
+            node = node.next;
+        }
+        return output;
     }
 
     @Override public String toString() {

--- a/tests/properties/applications/SimulationSpecificationGenerator.java
+++ b/tests/properties/applications/SimulationSpecificationGenerator.java
@@ -25,14 +25,14 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
     }
 
     @Override public SimulationSpecification generate(SourceOfRandomness r, GenerationStatus status) {
-        SimulationSpecification result = new SimulationSpecification();
+        SimulationSpecification generatedSpecification = new SimulationSpecification();
         // I add one to these random numbers so I don't end up with 0 machines
         // or 0 jobs.
         int numMachines = r.nextInt(MAX_MACHINES) + 1;
         int numJobs = r.nextInt(MAX_JOBS) + 1;
 
-        result.setNumMachines(numMachines);
-        result.setNumJobs(numJobs);
+        generatedSpecification.setNumMachines(numMachines);
+        generatedSpecification.setNumJobs(numJobs);
 
         // Ugh – the annoying problem of the indices starting at one again
         // so I have to make the array one too large and skip the first
@@ -42,13 +42,13 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
             // Changeover times can be 0 so I don't need to add 1 here.
             changeOverTimes[i] = r.nextInt(MAX_CHANGEOVER_TIME);
         }
-        result.setChangeOverTimes(changeOverTimes);
+        generatedSpecification.setChangeOverTimes(changeOverTimes);
 
         JobSpecification[] jobSpecifications = new JobSpecification[numJobs + 1];
         for (int i=1; i<=numJobs; ++i) {
             jobSpecifications[i] = new JobSpecification();
         }
-        result.setJobSpecification(jobSpecifications);
+        generatedSpecification.setJobSpecification(jobSpecifications);
         for (int i=1; i<=numJobs; ++i) {
             int numTasks = r.nextInt(MAX_TASKS) + 1;
             jobSpecifications[i].setNumTasks(numTasks);
@@ -61,10 +61,10 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
                 specificationsForTasks[2 * (j - 1) + 1] = theMachine;
                 specificationsForTasks[2 * (j - 1) + 2] = theTaskTime;
             }
-            result.setSpecificationsForTasks(i, specificationsForTasks);
+            generatedSpecification.setSpecificationsForTasks(i, specificationsForTasks);
         }
 
-        return result;
+        return generatedSpecification;
     }
 
     /**


### PR DESCRIPTION
SpecificationReader no longer creates a JobSpecification, instead directly populating an array of Jobs.  Various "scaffolding" measures have been added to support this.  This is in draft because several tests are currently failing; however, the core functionality of this change is written (if not necessarily correctly), and many of the failures will simply require either editing tests to work better with the new architecture or adding helper functions for this purpose.